### PR TITLE
chore: remove unused pytest dependency and references

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
             -   name: Run the automated tests
                 run: |
                     poetry build
-            -   name: Upload pytest test results
+            -   name: Upload build artifacts
                 uses: actions/upload-artifact@v7
                 with:
                     name: build-${{ matrix.python-version }}
@@ -67,10 +67,10 @@ jobs:
             -   name: Run the automated tests
                 run: |
                     poetry run tox run -e ${{ matrix.python-version }}
-            -   name: Upload pytest test results
+            -   name: Upload coverage results
                 uses: actions/upload-artifact@v7
                 with:
-                    name: pytest-results-${{ matrix.python-version }}
+                    name: coverage-results-${{ matrix.python-version }}
                     path: coverage.xml
 
     coverage-badge:
@@ -86,7 +86,7 @@ jobs:
             -   name: Download coverage artifact
                 uses: actions/download-artifact@v8
                 with:
-                    name: pytest-results-3.14
+                    name: coverage-results-3.14
             -   name: Run coverage badge
                 run: |
                     sudo apt-get install xq

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,25 +386,6 @@ files = [
 ]
 
 [[package]]
-name = "exceptiongroup"
-version = "1.3.1"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["dev"]
-markers = "python_version == \"3.10\""
-files = [
-    {file = "exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598"},
-    {file = "exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"},
-]
-
-[package.dependencies]
-typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
-
-[package.extras]
-test = ["pytest (>=6)"]
-
-[[package]]
 name = "filelock"
 version = "3.29.5"
 description = "A platform independent file lock."
@@ -432,18 +413,6 @@ files = [
 mccabe = ">=0.7.0,<0.8.0"
 pycodestyle = ">=2.14.0,<2.15.0"
 pyflakes = ">=3.4.0,<3.5.0"
-
-[[package]]
-name = "iniconfig"
-version = "2.3.0"
-description = "brain-dead simple config-ini parsing"
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
-    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
-]
 
 [[package]]
 name = "librt"
@@ -796,21 +765,6 @@ files = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.20.0"
-description = "Pygments is a syntax highlighting package written in Python."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
-    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
-]
-
-[package.extras]
-windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
 name = "pyproject-api"
 version = "1.10.1"
 description = "API to interact with the python pyproject.toml based projects"
@@ -825,30 +779,6 @@ files = [
 [package.dependencies]
 packaging = ">=25"
 tomli = {version = ">=2.3", markers = "python_version < \"3.11\""}
-
-[[package]]
-name = "pytest"
-version = "9.1.1"
-description = "pytest: simple powerful testing with Python"
-optional = false
-python-versions = ">=3.10"
-groups = ["dev"]
-files = [
-    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
-    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1.0.1"
-packaging = ">=22"
-pluggy = ">=1.5,<2"
-pygments = ">=2.7.2"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1072,4 +1002,4 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "dceeffc6a77d5ffba39688fe33d5cc9c18751765b4e4bcd9f27a558fba5aeeca"
+content-hash = "40eb558eb620f0c3ab3378c72a65a230f743ea006ff26ee1b4ef469d7090dca8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ packages = [
 
 [tool.poetry.group.dev.dependencies]
 coverage = "7.15.0"
-pytest = "9.1.1"
 flake8 = "7.3.0"
 deepdiff = "9.1.0"
 mypy = "2.1.0"

--- a/tox.toml
+++ b/tox.toml
@@ -4,7 +4,6 @@ env_list = ["lint", "type", "3.10", "3.11", "3.12", "3.13", "3.14"]
 [env_run_base]
 description = "Run unit tests"
 deps = [
-    "pytest>=8",
     "coverage>=7",
     "deepdiff>=8",
 ]


### PR DESCRIPTION
## Summary
- Remove unused pytest dev dependency and its tox dependency.
- Regenerate Poetry lockfile after dependency removal.
- Rename CI artifact labels from pytest to build/coverage results because tests run via unittest.

## Verification
- poetry install
- poetry run python -m unittest discover -v
- poetry run tox run -e 3.14
- poetry run tox run -e lint,type