### PR TITLE
fix: resolve documentation and metadata discrepancies

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -64,7 +64,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at <jensenthomas@siemens.com>
-or <hakandilek@gmail.com>. All complaints will be reviewed and investigated promptly and fairly.
+or <hakan.dilek@siemens.com>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ involved. The community looks forward to your contributions. 🎉
 
 This project and everyone participating in it is governed by our [Code of Conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
-to <jensenthomas@siemens.com> or <hakandilek@gmail.com>.
+to <jensenthomas@siemens.com> or <hakan.dilek@siemens.com>.
 
 
 ## I Have a Question
@@ -84,7 +84,7 @@ following steps in advance to help us fix any potential bug as fast as possible.
 
 > You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue
 > tracker, or elsewhere in public. Instead, sensitive bugs must be sent by email to <jensenthomas@siemens.com> or
-> <hakandilek@gmail.com>.
+> <hakan.dilek@siemens.com>.
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MIT
 
 Thomas Jensen <jensenthomas@siemens.com>
-Hakan Dilek <hakandilek@gmail.com>
+Hakan Dilek <hakan.dilek@siemens.com>
 Leo Reinmann <leo.reinmann@siemens.com>

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ This will save the Standard BOM to the file without the `.dependencies` field, w
 
 ## Create a Standard BOM document programmatically
 
-The `StandardBom` class is a subclass of the `cyclonedx.bom.Bom` class from the upstream library
-[cyclonedx-python-lib](https://github.com/CycloneDX/cyclonedx-python-lib) since this library is a wrapper of the
-model objects from the upstream library.
+The `StandardBom` class wraps the `cyclonedx.model.bom.Bom` class from the upstream library
+[cyclonedx-python-lib](https://github.com/CycloneDX/cyclonedx-python-lib). This library provides convenience wrappers
+around model objects from the upstream library.
 
 ```python
 from siemens_standard_bom.model import StandardBom, Component, ComponentType

--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ The `StandardBom` class wraps the `cyclonedx.model.bom.Bom` class from the upstr
 around model objects from the upstream library.
 
 ```python
-from siemens_standard_bom.model import StandardBom, Component, ComponentType
+from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalContact
+from siemens_standard_bom.model import StandardBom
 
 bom = StandardBom()
 bom.add_author(OrganizationalContact(name='John Doe'))
@@ -87,8 +88,9 @@ You can also use the Standard BOM wrapper classes to create and edit the Standar
 For example, you can do the following similar to the example abode:
 
 ```python
-from siemens_standard_bom.model import StandardBom, Component, ComponentType, SbomComponent
+from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.contact import OrganizationalContact
+from siemens_standard_bom.model import StandardBom, SbomComponent
 
 bom = StandardBom()
 bom.add_author(OrganizationalContact(name='John Doe'))


### PR DESCRIPTION
## Summary
Corrects non-functional discrepancies in documentation and project metadata. No library behavior changes.

## Changes
- **docs(README):** Fix incorrect claim that `StandardBom` is a *subclass* of `cyclonedx.model.bom.Bom`; it is a **wrapper** (composition).
- **docs(README):** Import `Component` / `ComponentType` from `cyclonedx.model.component` in the code examples instead of re-importing them from `siemens_standard_bom.model` (breaks under the strict-mypy setup the README recommends).
- **chore:** Unify the maintainer email across codebase

## Testing
`poetry run tox run` — lint (flake8), types (mypy strict), unit tests on Python 3.10–3.14.

## Notes
- Non-breaking.
- Draft pending review.
