### PR TITLE
ci: reduce workflow duplication

### DIFF
--- a/.github/actions/setup-poetry-project/action.yml
+++ b/.github/actions/setup-poetry-project/action.yml
@@ -1,0 +1,33 @@
+name: Setup Poetry project
+description: Install Poetry, configure Python, and install project dependencies.
+
+inputs:
+    python-version:
+        description: Python version to configure for Poetry.
+        required: true
+    install-args:
+        description: Arguments passed to poetry install.
+        required: false
+        default: --no-root
+
+runs:
+    using: composite
+    steps:
+        -   name: Install Poetry
+            shell: bash
+            run: |
+                pipx install poetry
+        -   name: Set up Python
+            uses: actions/setup-python@v6
+            with:
+                python-version: ${{ inputs.python-version }}
+                cache: poetry
+                cache-dependency-path: poetry.lock
+        -   name: Set Poetry environment
+            shell: bash
+            run: |
+                poetry env use ${{ inputs.python-version }}
+        -   name: Install dependencies
+            shell: bash
+            run: |
+                poetry install ${{ inputs.install-args }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,7 @@ jobs:
             -   name: Install dependencies
                 run: |
                     poetry install --no-root
-            -   name: Run the automated tests
+            -   name: Build package
                 run: |
                     poetry build
             -   name: Upload build artifacts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,21 +13,10 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v7
-            -   name: Install Poetry
-                run: |
-                    pipx install poetry
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
+            -   name: Set up Poetry project
+                uses: ./.github/actions/setup-poetry-project
                 with:
                     python-version: ${{ matrix.python-version }}
-                    cache: poetry
-                    cache-dependency-path: poetry.lock
-            -   name: Set Poetry environment
-                run: |
-                    poetry env use ${{ matrix.python-version }}
-            -   name: Install dependencies
-                run: |
-                    poetry install --no-root
             -   name: Build package
                 run: |
                     poetry build
@@ -49,21 +38,10 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v7
-            -   name: Install Poetry
-                run: |
-                    pipx install poetry
-            -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v6
+            -   name: Set up Poetry project
+                uses: ./.github/actions/setup-poetry-project
                 with:
                     python-version: ${{ matrix.python-version }}
-                    cache: poetry
-                    cache-dependency-path: poetry.lock
-            -   name: Set Poetry environment
-                run: |
-                    poetry env use ${{ matrix.python-version }}
-            -   name: Install dependencies
-                run: |
-                    poetry install --no-root
             -   name: Run the automated tests
                 run: |
                     poetry run tox run -e ${{ matrix.python-version }}
@@ -106,21 +84,10 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v7
-            -   name: Install Poetry
-                run: |
-                    pipx install poetry
-            -   name: Set up Python
-                uses: actions/setup-python@v6
+            -   name: Set up Poetry project
+                uses: ./.github/actions/setup-poetry-project
                 with:
                     python-version: '3.14'
-                    cache: poetry
-                    cache-dependency-path: poetry.lock
-            -   name: Set Poetry environment
-                run: |
-                    poetry env use 3.14
-            -   name: Install dependencies
-                run: |
-                    poetry install --no-root
             -   name: Run the linting
                 run: |
                     poetry run tox run -e lint,type

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,21 +24,11 @@ jobs:
         steps:
             -   name: Checkout
                 uses: actions/checkout@v7
-            -   name: Install Poetry
-                run: |
-                    pipx install poetry
-            -   name: Set up Python
-                uses: actions/setup-python@v6
+            -   name: Set up Poetry project
+                uses: ./.github/actions/setup-poetry-project
                 with:
                     python-version: '3.10'
-                    cache: poetry
-                    cache-dependency-path: poetry.lock
-            -   name: Set Poetry environment
-                run: |
-                    poetry env use 3.10
-            -   name: Install dependencies
-                run: |
-                    poetry install --sync --no-interaction
+                    install-args: --sync --no-interaction
             -   name: Package project
                 run: |
                     poetry build


### PR DESCRIPTION
## Summary
- Rename the package build workflow step so it describes `poetry build`.
- Move the repeated Poetry/Python setup into a local composite GitHub Action used by the build, test, lint, and release jobs.

## Note
- The coverage badge `xq` install step is unchanged by request.