### PR TITLE
refactor: simplify implementation and reduce duplication

### DIFF
--- a/badges/coverage-python.svg
+++ b/badges/coverage-python.svg
@@ -17,7 +17,7 @@
         <text x="55.0" y="14">python:coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="134.0" y="15" fill="#010101" fill-opacity=".3">97.1%</text>
-        <text x="133.0" y="14">97.1%</text>
+        <text x="134.0" y="15" fill="#010101" fill-opacity=".3">97.4%</text>
+        <text x="133.0" y="14">97.4%</text>
     </g>
 </svg>

--- a/badges/coverage-python.svg
+++ b/badges/coverage-python.svg
@@ -17,7 +17,7 @@
         <text x="55.0" y="14">python:coverage</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="134.0" y="15" fill="#010101" fill-opacity=".3">97.3%</text>
-        <text x="133.0" y="14">97.3%</text>
+        <text x="134.0" y="15" fill="#010101" fill-opacity=".3">97.1%</text>
+        <text x="133.0" y="14">97.1%</text>
     </g>
 </svg>

--- a/siemens_standard_bom/immutable.py
+++ b/siemens_standard_bom/immutable.py
@@ -2,40 +2,16 @@
 # Copyright (c) Siemens AG 2019-2025 ALL RIGHTS RESERVED
 # SPDX-License-Identifier: MIT
 #
-from dataclasses import dataclass
-from typing import Iterable, TypeVar, Generic, Union, Tuple, Any, Iterator
+from collections.abc import Iterable
+from typing import TypeVar, cast
 
 T = TypeVar('T')
 
 
-@dataclass(frozen=True)
-class ImmutableList(Generic[T], Iterable[T]):
-    _items: Tuple[T, ...]
+class ImmutableList(tuple[T, ...]):
+    __slots__ = ()
 
-    def __init__(self, *args: Union[T, Iterable[T]]) -> None:
+    def __new__(cls, *args: T | Iterable[T]) -> 'ImmutableList[T]':
         if len(args) == 1 and isinstance(args[0], Iterable):
-            items = tuple(args[0])
-        else:
-            items = args
-        object.__setattr__(self, '_items', items)
-
-    def __len__(self) -> int:
-        return len(self._items)
-
-    def __getitem__(self, index: int) -> T:
-        return self._items[index]
-
-    def __iter__(self) -> Iterator[T]:
-        return iter(self._items)
-
-    def __str__(self) -> str:
-        return str(self._items)
-
-    def __eq__(self, other: Any) -> bool:
-        if isinstance(other, ImmutableList):
-            return self._items == other._items
-        eq: bool = self._items == other
-        return eq
-
-    def __hash__(self) -> int:
-        return hash(self._items)
+            return super().__new__(cls, args[0])
+        return super().__new__(cls, cast(tuple[T, ...], args))

--- a/siemens_standard_bom/model.py
+++ b/siemens_standard_bom/model.py
@@ -53,6 +53,19 @@ def is_source_artifact(ex_ref: ExternalReference) -> bool:
             or is_local_source_archive(ex_ref))
 
 
+def _get_hash_value(hashes: Iterable[HashType], algorithm: HashAlgorithm) -> Optional[str]:
+    h = next(filter(lambda hash_type: hash_type.alg == algorithm, hashes), None)
+    return h.content if h else None
+
+
+def _set_hash_value(hashes: SortedSet[HashType], algorithm: HashAlgorithm, value: str) -> None:
+    h = next(filter(lambda hash_type: hash_type.alg == algorithm, hashes), None)
+    if h:
+        h.content = value
+    else:
+        hashes.add(HashType(alg=algorithm, content=value))
+
+
 class ExternalComponent:
     reference: ExternalReference
 
@@ -407,15 +420,10 @@ class SbomComponent:
         self._set_hash(HashAlgorithm.SHA_512, value)
 
     def _get_hash(self, algorithm: HashAlgorithm) -> Optional[str]:
-        h = next(filter(lambda hash_type: hash_type.alg == algorithm, self.component.hashes), None)
-        return h.content if h else None
+        return _get_hash_value(self.component.hashes, algorithm)
 
     def _set_hash(self, algorithm: HashAlgorithm, value: str) -> None:
-        h = next(filter(lambda hash_type: hash_type.alg == algorithm, self.component.hashes), None)
-        if h:
-            h.content = value
-        else:
-            self.component.hashes.add(HashType(alg=algorithm, content=value))
+        _set_hash_value(self.component.hashes, algorithm, value)
 
 
 class SourceArtifact:
@@ -496,15 +504,10 @@ class SourceArtifact:
         self._set_hash(HashAlgorithm.SHA_512, value)
 
     def _get_hash(self, algorithm: HashAlgorithm) -> Optional[str]:
-        h = next(filter(lambda hash_type: hash_type.alg == algorithm, self.external_ref.hashes), None)
-        return h.content if h else None
+        return _get_hash_value(self.external_ref.hashes, algorithm)
 
     def _set_hash(self, algorithm: HashAlgorithm, value: str) -> None:
-        h = next(filter(lambda hash_type: hash_type.alg == algorithm, self.external_ref.hashes), None)
-        if h:
-            h.content = value
-        else:
-            self.external_ref.hashes.add(HashType(alg=algorithm, content=value))
+        _set_hash_value(self.external_ref.hashes, algorithm, value)
 
 
 class SbomNature(str, Enum):

--- a/siemens_standard_bom/model.py
+++ b/siemens_standard_bom/model.py
@@ -66,6 +66,10 @@ def _set_hash_value(hashes: SortedSet[HashType], algorithm: HashAlgorithm, value
         hashes.add(HashType(alg=algorithm, content=value))
 
 
+def _is_true_value(value: Optional[str]) -> bool:
+    return value in ("True", "true")
+
+
 class ExternalComponent:
     reference: ExternalReference
 
@@ -239,7 +243,7 @@ class SbomComponent:
 
     @property
     def direct_dependency(self) -> bool:
-        return self.get_custom_property(self.component, PROPERTY_DIRECT_DEPENDENCY) in ["True", "true"]
+        return _is_true_value(self.get_custom_property(self.component, PROPERTY_DIRECT_DEPENDENCY))
 
     @direct_dependency.setter
     def direct_dependency(self, value: str) -> None:
@@ -247,7 +251,7 @@ class SbomComponent:
 
     @property
     def internal(self) -> bool:
-        return self.get_custom_property(self.component, PROPERTY_INTERNAL) in ["True", "true"]
+        return _is_true_value(self.get_custom_property(self.component, PROPERTY_INTERNAL))
 
     @internal.setter
     def internal(self, value: bool) -> None:
@@ -674,7 +678,7 @@ class StandardBom:
 
     @property
     def vcs_clean(self) -> bool:
-        return SbomComponent.get_custom_property(self.bom.metadata.component, PROPERTY_VCS_CLEAN) in ["True", "true"]
+        return _is_true_value(SbomComponent.get_custom_property(self.bom.metadata.component, PROPERTY_VCS_CLEAN))
 
     @vcs_clean.setter
     def vcs_clean(self, value: bool) -> None:
@@ -699,7 +703,7 @@ class StandardBom:
 
     @property
     def internal(self) -> bool:
-        return SbomComponent.get_custom_property(self.bom.metadata.component, PROPERTY_INTERNAL) in ["True", "true"]
+        return _is_true_value(SbomComponent.get_custom_property(self.bom.metadata.component, PROPERTY_INTERNAL))
 
     @internal.setter
     def internal(self, value: bool) -> None:

--- a/siemens_standard_bom/parser.py
+++ b/siemens_standard_bom/parser.py
@@ -34,15 +34,11 @@ class StandardBomParser:
         output_file.parent.mkdir(exist_ok=True, parents=True)
 
         writer = JsonV1Dot6(bom=sbom.bom)
-        writer.output_to_file(filename=output_filename, allow_overwrite=True, indent=indent)
+        output = writer.output_as_string(indent=indent)
 
         if not with_dependencies:
-            StandardBomParser._patch_to_remove_dependencies(output_filename, indent)
-
-    @staticmethod
-    def _patch_to_remove_dependencies(output_filename: str, indent: int = 4) -> None:
-        with open(output_filename, 'r') as file:
-            data = json.load(file)
+            data = json.loads(output)
             data.pop('dependencies', None)
-        with open(output_filename, 'w') as file:
-            json.dump(data, file, indent=indent)
+            output = json.dumps(data, indent=indent)
+
+        output_file.write_text(output, encoding='utf-8')

--- a/tests/test_immutable_list.py
+++ b/tests/test_immutable_list.py
@@ -1,7 +1,6 @@
 # Copyright (c) Siemens AG 2019-2025 ALL RIGHTS RESERVED
 # SPDX-License-Identifier: MIT
 import unittest
-from dataclasses import FrozenInstanceError
 
 from sortedcontainers import SortedSet
 
@@ -78,18 +77,16 @@ class ImmutableListTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             il[0] = 10  # type: ignore[index]
 
-    def test_immutable_items_attribute(self) -> None:
+    def test_no_instance_attributes(self) -> None:
         il = ImmutableList(1, 2, 3, 4, 5)
-        with self.assertRaises(FrozenInstanceError):
-            il.__setattr__('_items', 10)
+        with self.assertRaises(AttributeError):
+            setattr(il, '_items', 10)
 
     def test_immutable_length(self) -> None:
-        items = [1, 2, 3, 4, 5]
-        il = ImmutableList[int](items)
-
-        items.append(6)
-
+        il = ImmutableList(1, 2, 3, 4, 5)
         self.assertEqual(len(il), 5)
+        with self.assertRaises(AttributeError):
+            il.append(6)  # type: ignore[attr-defined]
 
     def test_map_values_from_a_tuple(self) -> None:
         values = (1, 2, 3, 4, 5)

--- a/tests/test_v3_parser_write.py
+++ b/tests/test_v3_parser_write.py
@@ -4,6 +4,8 @@
 #
 import json
 from os import path
+from pathlib import Path
+from unittest.mock import patch
 
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.model.license import LicenseExpression
@@ -117,6 +119,36 @@ class SbomV3ParserWriteTestCase(AbstractSbomComparingTestCase):
         with open(output_filename, 'r') as file:
             data = json.load(file)
             self.assertNotIn("dependencies", data)
+
+    def test_save_writes_output_file_once(self) -> None:
+        output_filename = "output/v3/single-write.cdx.json"
+
+        sbom = StandardBom()
+        sbom.add_component(Component(name="Dummy", version="0.0.1"))
+
+        original_write_text = Path.write_text
+        writes: list[Path] = []
+
+        def counting_write_text(
+            self_path: Path,
+            data: str,
+            encoding: str | None = None,
+            errors: str | None = None,
+            newline: str | None = None,
+        ) -> int:
+            writes.append(self_path)
+            return original_write_text(self_path, data, encoding=encoding, errors=errors, newline=newline)
+
+        with patch.object(Path, "write_text", counting_write_text):
+            StandardBomParser.save(sbom, output_filename, with_dependencies=False)
+
+        self.assertEqual(len(writes), 1)
+        self.assertEqual(writes[0], Path(output_filename))
+
+        with open(output_filename, 'r') as file:
+            data = json.load(file)
+            self.assertNotIn("dependencies", data)
+            self.assertEqual(data["components"][0]["name"], "Dummy")
 
     def test_write_with_added_license(self) -> None:
         output_filename = "output/v3/with_added_license.json"


### PR DESCRIPTION
## Summary
- Write the SBOM output once in `StandardBomParser.save()` and add a regression test asserting a single write on the `with_dependencies=False` path.
- Share hash accessor helpers between `SbomComponent` and `SourceArtifact`.
- Share the boolean custom-property parsing used by several model properties.
- Make `ImmutableList` a `tuple` subclass while preserving the existing constructor interface.

## Testing
- `poetry run tox run`